### PR TITLE
Add a link to Firefox plugin which can automatically fix the .odm download button to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Overdrive Libby MP3 Downloader
+# OverDrive Libby MP3 Downloader
 
-As of late 2024, Overdrive discontinued their Overdrive Media Console application in favor of the Libby application. This works to play the audiobooks, but doesn't allow you access to the raw, non-DRM MP3 files any more. This means many people who use things like standalone MP3 players can no longer use them to listen to audiobooks from the library. This code allows you to again download the MP3s.  
+As of late 2024, OverDrive discontinued their OverDrive Media Console application in favor of the Libby application. This works to play the audiobooks, but doesn't allow you access to the raw, non-DRM MP3 files any more. This means many people who use things like standalone MP3 players can no longer use them to listen to audiobooks from the library. This code allows you to again download the MP3s.  
 
 NOTE: There's no telling how long this will work, but if you don't see a message here saying it no longer works, it should still work.
 
@@ -25,7 +25,9 @@ NOTE: Once you have the .license file, do not delete it until you have all the M
 You can rerun the code on the ODM file multiple times, but it will skip any files you already have. if you need it to download the file(s) again, delete the MP3(s) or the cover image and it will re-download them.
 
 ## Obtain an ODM file
-This is a little trickier than it used to be. Here is how I do it... Once you checkout an audiobook from Overdrive/Libby, go to your loans on the Overdrive site for you library. This URL will look like https://YOURLIBRARY.overdrive.com/account/loans - some actual examples are:  
+You can install the [OverDrive Download .odm Button Firefox plugin](https://github.com/bemehiser/overdrive-mp3-button) which will use find-and-replace to automatically fix the button. Alternately, use the following instructions to manually generate the url.
+
+Obtaning an ODM file is a little trickier than it used to be. Here is how I do it... Once you checkout an audiobook from OverDrive/Libby, go to your loans on the OverDrive site for you library. This URL will look like https://YOURLIBRARY.overdrive.com/account/loans - some actual examples are:  
 * https://wakegov.overdrive.com/account/loans
 * https://hcplc.overdrive.com/account/loans
 * https://alexandria.overdrive.com/account/loans


### PR DESCRIPTION
I wrote this Firefox plugin which works flawlessly for me with my library overdrive website. 
(It might not show up in the firefox plugin store just yet, because it's currently in review.)